### PR TITLE
Replace parameter name for Solr path for Browse (TMART-312)

### DIFF
--- a/config/Config-extra.php.sample-london
+++ b/config/Config-extra.php.sample-london
@@ -10,7 +10,7 @@ EOD
 com.rwg.solr.browse.path   = '/solr/browse/select/'
 com.rwg.solr.update.path = '/solr/browse/dataimport/'
 com.recomdata.solr.baseURL = "${com.rwg.solr.scheme}://${com.rwg.solr.host}" +
-                             "${new File(com.rwg.solr.path).parent}"
+                             "${new File(com.rwg.solr.browse.path).parent}"
 
 def fileStoreDirectory = new File(System.getenv('HOME'), '.grails/transmart-filestore')
 def fileImportDirectory = new File(System.getProperty("java.io.tmpdir"), 'transmart-fileimport')


### PR DESCRIPTION
There is a conflict between Solr paths for Browse and GWAS that are got from the same parameter
