### PR TITLE
Multiple fixes in stored procedures

### DIFF
--- a/ddl/oracle/tm_cz/procedures/i2b2_load_clinical_data.sql
+++ b/ddl/oracle/tm_cz/procedures/i2b2_load_clinical_data.sql
@@ -663,11 +663,11 @@ BEGIN
      race_cd
     )
 	select a.usubjid,
-	      nvl(max(case when upper(a.data_label) = 'AGE'
-					   then case when is_number(a.data_value) = 1 then 0 else to_number(a.data_value) end
-		               when upper(a.data_label) like '%(AGE)' 
-					   then case when is_number(a.data_value) = 1 then 0 else to_number(a.data_value) end
-					   else null end),0) as age,
+	      max(case when upper(a.data_label) = 'AGE'
+				   then case when is_number(a.data_value) = 1 then null else to_number(a.data_value) end
+	               when upper(a.data_label) like '%(AGE)' 
+				   then case when is_number(a.data_value) = 1 then null else to_number(a.data_value) end
+				   else null end) as age,
 		  --nvl(max(decode(upper(a.data_label),'AGE',data_value,null)),0) as age,
 		  nvl(max(case when upper(a.data_label) = 'SEX' then a.data_value
 		           when upper(a.data_label) like '%(SEX)' then a.data_value

--- a/ddl/oracle/tm_cz/procedures/i2b2_load_clinical_data_16_11.sql
+++ b/ddl/oracle/tm_cz/procedures/i2b2_load_clinical_data_16_11.sql
@@ -650,11 +650,11 @@ BEGIN
      race_cd
     )
 	select a.usubjid,
-	      nvl(max(case when upper(a.data_label) = 'AGE'
-					   then case when is_number(a.data_value) = 1 then 0 else to_number(a.data_value) end
-		               when upper(a.data_label) like '%(AGE)' 
-					   then case when is_number(a.data_value) = 1 then 0 else to_number(a.data_value) end
-					   else null end),0) as age,
+	      max(case when upper(a.data_label) = 'AGE'
+				   then case when is_number(a.data_value) = 1 then null else to_number(a.data_value) end
+	               when upper(a.data_label) like '%(AGE)' 
+				   then case when is_number(a.data_value) = 1 then null else to_number(a.data_value) end
+				   else null end) as age,
 		  --nvl(max(decode(upper(a.data_label),'AGE',data_value,null)),0) as age,
 		  nvl(max(case when upper(a.data_label) = 'SEX' then a.data_value
 		           when upper(a.data_label) like '%(SEX)' then a.data_value

--- a/ddl/oracle/tm_cz/procedures/i2b2_load_clinical_data_backup.sql
+++ b/ddl/oracle/tm_cz/procedures/i2b2_load_clinical_data_backup.sql
@@ -642,11 +642,11 @@ BEGIN
      race_cd
     )
 	select a.usubjid,
-	      nvl(max(case when upper(a.data_label) = 'AGE'
-					   then case when is_number(a.data_value) = 1 then 0 else to_number(a.data_value) end
-		               when upper(a.data_label) like '%(AGE)' 
-					   then case when is_number(a.data_value) = 1 then 0 else to_number(a.data_value) end
-					   else null end),0) as age,
+	      max(case when upper(a.data_label) = 'AGE'
+				   then case when is_number(a.data_value) = 1 then null else to_number(a.data_value) end
+	               when upper(a.data_label) like '%(AGE)' 
+				   then case when is_number(a.data_value) = 1 then null else to_number(a.data_value) end
+				   else null end) as age,
 		  --nvl(max(decode(upper(a.data_label),'AGE',data_value,null)),0) as age,
 		  nvl(max(case when upper(a.data_label) = 'SEX' then a.data_value
 		           when upper(a.data_label) like '%(SEX)' then a.data_value

--- a/ddl/oracle/tm_lz/procedures/i2b2_load_clinical_data_backup.sql
+++ b/ddl/oracle/tm_lz/procedures/i2b2_load_clinical_data_backup.sql
@@ -642,11 +642,11 @@ BEGIN
      race_cd
     )
 	select a.usubjid,
-	      nvl(max(case when upper(a.data_label) = 'AGE'
-					   then case when is_number(a.data_value) = 1 then 0 else to_number(a.data_value) end
-		               when upper(a.data_label) like '%(AGE)' 
-					   then case when is_number(a.data_value) = 1 then 0 else to_number(a.data_value) end
-					   else null end),0) as age,
+	      max(case when upper(a.data_label) = 'AGE'
+				   then case when is_number(a.data_value) = 1 then null else to_number(a.data_value) end
+	               when upper(a.data_label) like '%(AGE)' 
+				   then case when is_number(a.data_value) = 1 then null else to_number(a.data_value) end
+				   else null end) as age,
 		  --nvl(max(decode(upper(a.data_label),'AGE',data_value,null)),0) as age,
 		  nvl(max(case when upper(a.data_label) = 'SEX' then a.data_value
 		           when upper(a.data_label) like '%(SEX)' then a.data_value

--- a/ddl/postgres/tm_cz/functions/i2b2_backout_trial.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_backout_trial.sql
@@ -77,7 +77,7 @@ BEGIN
 
 	-- retrieve topNode for study with given trial id (trialid)
 	begin
-	select c_fullname from i2b2metadata.i2b2 where sourcesystem_cd = trialid and c_hlevel = 1 into topNode;
+	select c_fullname from i2b2metadata.i2b2 where sourcesystem_cd = trialid order by c_hlevel asc limit 1 into topNode;
 	get diagnostics rowCt := ROW_COUNT;
 	exception
 	when others then

--- a/ddl/postgres/tm_cz/functions/i2b2_load_annotation_deapp.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_load_annotation_deapp.sql
@@ -209,7 +209,7 @@ BEGIN
 	select distinct d.gpl_id
 	,d.probe_id
 	,d.gene_symbol
-	,case when d.gene_id is null then null else d.gene_id::numeric end as gene_id
+	,case when d.gene_id is null then null when d.gene_id='' then null else d.gene_id::numeric end as gene_id
 	,p.probeset_id
 	,coalesce(d.organism,'Homo sapiens')
 	from tm_lz.lt_src_deapp_annot d

--- a/ddl/postgres/tm_cz/functions/i2b2_load_clinical_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_load_clinical_data.sql
@@ -783,11 +783,11 @@ BEGIN
      race_cd
     )
 	select a.usubjid,
-	      coalesce(max(case when upper(a.data_label) = 'AGE'
-					   then case when tm_cz.is_numeric(a.data_value) = 1 then 0 else round(a.data_value::numeric) end
-		               when upper(a.data_label) like '%(AGE)' 
-					   then case when tm_cz.is_numeric(a.data_value) = 1 then 0 else round(a.data_value::numeric) end
-					   else null end),0) as age,
+	      max(case when upper(a.data_label) = 'AGE'
+				   then case when tm_cz.is_numeric(a.data_value) = 1 then null else round(a.data_value::numeric) end
+		           when upper(a.data_label) like '%(AGE)' 
+				   then case when tm_cz.is_numeric(a.data_value) = 1 then null else round(a.data_value::numeric) end
+				   else null end) as age,
 		  coalesce(max(case when upper(a.data_label) = 'SEX' then a.data_value
 		           when upper(a.data_label) like '%(SEX)' then a.data_value
 				   when upper(a.data_label) = 'GENDER' then a.data_value


### PR DESCRIPTION
The psql bulk loader seems to insert empty CSV fields as empty strings in the table, rather than NULLs. The function now correctly checks for NULL values and empty string values.
