### PR TITLE
restore rnaseq data loading for pivoted data files

### DIFF
--- a/samples/common/process_params.inc
+++ b/samples/common/process_params.inc
@@ -1,4 +1,4 @@
-# Requires that the DATATYPE parameter is set and not empty
+# Requires that the UPLOAD_DATA_TYPE parameter is set and not empty
 # Optionally expecting values for the following parameters:
 #   DATA_LOCATION, STUDY_NAME, STUDY_ID, SECURITY_REQUIRED, TOP_NODE_PREFIX
 

--- a/samples/postgres/load_rnaseq.sh
+++ b/samples/postgres/load_rnaseq.sh
@@ -5,7 +5,7 @@
 # General optional parameters:
 #   DATA_LOCATION, STUDY_NAME, STUDY_ID
 # Specific mandatory parameters for this upload script:
-#   RNASEQ_DATA_FILE, SUBJECT_SAMPLE_MAPPING, PLATFORM_FILE
+#   RNASEQ_DATA_FILE, SUBJECT_SAMPLE_MAPPING, R_JOBS_PSQL
 # Specific optional parameters for this upload script:
 #   TOP_NODE_PREFIX, SECURITY_REQUIRED, SOURCE_CD 
 
@@ -13,6 +13,32 @@
 UPLOAD_SCRIPTS_DIRECTORY=$(dirname "$0")
 UPLOAD_DATA_TYPE="rnaseq"
 source "$UPLOAD_SCRIPTS_DIRECTORY/process_params.inc"
+
+# Check if mandatory variables are set
+if [ -z "$STUDY_ID" ] || [ -z "$RNASEQ_DATA_FILE" ]; then
+	echo "Following variables need to be set:"
+	echo "    STUDY_ID=$STUDY_ID"
+	echo "    RNASEQ_DATA_FILE=$RNASEQ_DATA_FILE"
+	exit -1
+fi
+
+if [ -z "$R_JOBS_PSQL" ]; then
+    if [ -z "$KETTLE_JOBS_PSQL" ]; then
+        echo "Error: Neither R_JOBS_PSQL nor KETTLE_JOBS_PSQL parameter has been set"
+        exit 1
+    else
+        R_JOBS_PSQL="${KETTLE_JOBS_PSQL}/../../R"
+    fi
+fi
+
+RSCRIPT="Rscript"
+if ! type "$RSCRIPT" 2>&1 > /dev/null; then
+    RSCRIPT="/opt/R/bin/Rscript"
+    if ! type "$RSCRIPT" > /dev/null; then
+        echo "Error: Rscript command not found"
+        exit 1
+    fi
+fi
 
 # Check if mandatory parameter values are provided
 if [ -z "$RNASEQ_DATA_FILE" ] || [ -z "$SUBJECT_SAMPLE_MAPPING" ] ; then
@@ -34,6 +60,18 @@ TOP_NODE="\\${TOP_NODE_PREFIX}\\${STUDY_NAME}\\"
 
 SOURCE_CD=${SOURCE_CD:-STD}
 
+# The unpivoted-file which will be loaded into the database
+RNASEQ_DATA_FILE_UPLOAD=${RNASEQ_DATA_FILE}.upload
+
+# Create the unpivoted file to be loaded into the database.
+echo "Start re-arranging input..."
+${RSCRIPT} ${R_JOBS_PSQL}/RNASeq/unpivot_RNASeq_data.R studyID=${STUDY_ID} \
+                                                       RNASeqFile=${RNASEQ_DATA_FILE} \
+                                                       dataOUT=${RNASEQ_DATA_FILE_UPLOAD}
+
+echo "unpivoted input stored in file: ${RNASEQ_DATA_FILE_UPLOAD}"
+echo ""
+
 # Upload SubjectSamplMap
   echo "Uploading SubjectSampleMap from: ${SUBJECT_SAMPLE_MAPPING} into the landing-zone"
   $PGSQL_BIN/psql <<_END
@@ -44,12 +82,12 @@ SOURCE_CD=${SOURCE_CD:-STD}
 _END
 
 # Upload data-file into the landing-zone
-  echo "Entering data from: ${RNASEQ_DATA_FILE} into the landing-zone"
+  echo "Entering data from: ${RNASEQ_DATA_FILE_UPLOAD} into the landing-zone"
   $PGSQL_BIN/psql <<_END
     truncate TABLE tm_lz.lt_src_rnaseq_data;
     \copy tm_lz.lt_src_rnaseq_data \
         ( trial_name, region_name, expr_id, readcount, normalized_readcount )  \
-        FROM '${RNASEQ_DATA_FILE}' WITH (FORMAT CSV, DELIMITER E'\t', HEADER, QUOTE E'\b');
+        FROM '${RNASEQ_DATA_FILE_UPLOAD}' WITH (FORMAT CSV, DELIMITER E'\t', HEADER, QUOTE E'\b');
 _END
 
 # transport data from the landing-zone into the transmart tables


### PR DESCRIPTION
The structure of the RNA-Seq data files which can be loaded into tranSMART very much resembles the structure of e.g. microarray expression data and acgh copy number data i.e. the observations for samples are in separate columns. The current upload pipeline does not support this and only accepts rnaseq data files formatted as is required for putting those into the landing zone.
This pull request should be merged simultaneously with a pull request for tranSMART-ETL on this same subject (improvement/upload-rnaseq-data)