### PR TITLE
Improve oracle loading scripts

### DIFF
--- a/ddl/oracle/.gitignore
+++ b/ddl/oracle/.gitignore
@@ -3,3 +3,4 @@
 */_grants.sql
 /GLOBAL/tablespaces.sql
 /runsql.sh
+/cross_grants.sql

--- a/ddl/oracle/biomart_user/items.json
+++ b/ddl/oracle/biomart_user/items.json
@@ -1042,17 +1042,6 @@
     } ]
   }, {
     "child" : {
-      "type" : "SYNONYM",
-      "owner" : "BIOMART_USER",
-      "name" : "BIRN"
-    },
-    "parents" : [ {
-      "type" : "TABLE",
-      "owner" : "I2B2METADATA",
-      "name" : "BIRN"
-    } ]
-  }, {
-    "child" : {
       "type" : "VIEW",
       "owner" : "BIOMART_USER",
       "name" : "BROWSE_ANALYSES_VIEW"

--- a/ddl/oracle/tm_cz/items.json
+++ b/ddl/oracle/tm_cz/items.json
@@ -1208,17 +1208,6 @@
     } ]
   }, {
     "child" : {
-      "type" : "SYNONYM",
-      "owner" : "TM_CZ",
-      "name" : "BIRN"
-    },
-    "parents" : [ {
-      "type" : "TABLE",
-      "owner" : "I2B2METADATA",
-      "name" : "BIRN"
-    } ]
-  }, {
-    "child" : {
       "type" : "TABLE",
       "owner" : "TM_CZ",
       "name" : "CATEGORY_PATH_EXCLUDED_WORDS"

--- a/lib/inc/oracle/GrantItem.groovy
+++ b/lib/inc/oracle/GrantItem.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2013-2014 The Hyve B.V.
+ *
+ * This file is part of transmart-data.
+ *
+ * Transmart-data is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * transmart-data.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package inc.oracle
+
+class GrantItem extends BasicItem {
+
+    String permission
+
+    GrantItem(Item grantedItem, permission, String grantee) {
+        assert grantedItem != null
+        assert grantee != null
+
+        this.owner = grantee
+        this.type = 'GRANT'
+        this.name = "${grantedItem.owner}.${grantedItem.name}"
+        this.permission = permission
+    }
+
+    @Override
+    String getData() {
+        "\nGRANT $permission ON $name TO $owner;\n"
+    }
+
+    @Override
+    boolean equals(Object obj) {
+        obj.getClass() == GrantItem &&
+                this.owner == obj.owner && this.name == obj.name &&
+                this.type == obj.type && this.permission == obj.permission
+    }
+
+    int hashCode() {
+        return type.hashCode() ^ name.hashCode() ^ owner.hashCode() ^
+                permission.hashCode()
+    }
+}


### PR DESCRIPTION
* Avoid loading all the grants before moving to the _cross files.
* No need to explicitly set permissions for cross-schema views and
  procedures to compile (such GRANTS are generated automatically,
  except if there's a cross object depending on another)
* Refresh all materialized views
* Recompile all schemas
* Report objects with errors

Also fixed references to objects that don't exist already.