### PR TITLE
foreign key breaks ETL on postgres

### DIFF
--- a/ddl/postgres/deapp/de_rbm_data_annotation_join.sql
+++ b/ddl/postgres/deapp/de_rbm_data_annotation_join.sql
@@ -21,5 +21,5 @@ ALTER TABLE ONLY de_rbm_data_annotation_join
 --
 -- Name: de_rbm_data_ann_jn_data_id_fk; Type: FK CONSTRAINT; Schema: deapp; Owner: -
 --
-ALTER TABLE ONLY de_rbm_data_annotation_join
-    ADD CONSTRAINT de_rbm_data_ann_jn_data_id_fk FOREIGN KEY (data_id) REFERENCES de_subject_rbm_data(id) ON DELETE CASCADE;
+--ALTER TABLE ONLY de_rbm_data_annotation_join
+--    ADD CONSTRAINT de_rbm_data_ann_jn_data_id_fk FOREIGN KEY (data_id) REFERENCES de_subject_rbm_data(id) ON DELETE CASCADE;


### PR DESCRIPTION
foreign key breaks ETL on postgres as table is partitioned and then postgres foreign keys do not work