### PR TITLE
Remove kettle.properties when sourcing vars

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -14,7 +14,7 @@ Config-extra.php BuildConfig.groovy:
 Config.groovy: Config-template.groovy Config-extra.php build-config.php
 	php build-config.php > $@
 
-DataSource.groovy: DataSource.groovy.php ../vars
+DataSource.groovy: DataSource.groovy.php
 	php -d 'variables_order=E' $< > $@
 
 TSCONFIG = $(TSUSER_HOME).grails/transmartConfig/
@@ -32,4 +32,4 @@ install: $(addprefix install_,$(FINAL_FILES))
 clean:
 	rm -f $(FINAL_FILES)
 
-.PHONY: install clean
+.PHONY: install clean DataSource.groovy

--- a/data/oracle/Makefile
+++ b/data/oracle/Makefile
@@ -1,7 +1,7 @@
 include ../common/makefile.inc
 include ../../lib/makefile.inc
 
-$(ENV_DIR)/$(TRANSMART_LOADER)/conf/Common.properties: Common.properties.php ../../vars
+$(ENV_DIR)/$(TRANSMART_LOADER)/conf/Common.properties: Common.properties.php
 	php -d variables_order=E $< > $@
 
 start_pool: $(NETTY_JAR_PATH) $(JDBC_DRIVER_ORA_PATH)
@@ -10,6 +10,6 @@ start_pool: $(NETTY_JAR_PATH) $(JDBC_DRIVER_ORA_PATH)
 		groovy -cp '$(CP_ORA):$(NETTY_JAR_PATH)' start_conn_pool.groovy \
 		-f pool-lock
 
-.PHONY: start_pool
+.PHONY: start_pool $(ENV_DIR)/$(TRANSMART_LOADER)/conf/Common.properties
 
 # vim: set filetype=make:

--- a/data/postgres/Makefile
+++ b/data/postgres/Makefile
@@ -11,9 +11,9 @@ row_counts:
 analyze:
 	$(PSQL_COMMAND) -c 'ANALYZE VERBOSE'
 
-$(ENV_DIR)/$(TRANSMART_LOADER)/conf/Common.properties: Common.properties.php ../../vars
+$(ENV_DIR)/$(TRANSMART_LOADER)/conf/Common.properties: Common.properties.php
 	php -d variables_order=E $< > $@
 
-.PHONY: row_counts analyze
+.PHONY: row_counts analyze $(ENV_DIR)/$(TRANSMART_LOADER)/conf/Common.properties
 
 # vim: set filetype=make:

--- a/env/Makefile
+++ b/env/Makefile
@@ -51,14 +51,14 @@ $(TRANSMART_BATCH_FILE):
 	curl -s -L -f -R -z '$@' -o '$@' '$(TRANSMART_BATCH_URL)'
 	@chmod +x '$@'
 
-batchdb-psql.properties: batchdb-psql.properties.php ../vars
+batchdb-psql.properties: batchdb-psql.properties.php
 	php -d variables_order=E '$<' > '$@'
 
-batchdb-oracle.properties: batchdb-oracle.properties.php ../vars
+batchdb-oracle.properties: batchdb-oracle.properties.php
 	php -d variables_order=E '$<' > '$@'
 
 # for redownload
-.PHONY: $(TRANSMART_BATCH_FILE)
+.PHONY: $(TRANSMART_BATCH_FILE) batchdb-psql.properties batchdb-oracle.properties
 
 $(GROOVY_ZIP):
 	curl -L "$(GROOVY_URL)" > $@

--- a/samples/common/makefile.inc
+++ b/samples/common/makefile.inc
@@ -51,8 +51,10 @@ $(LOAD_ANNOTATION_TARGETS):
 $(LOAD_REF_ANNOTATION_TARGETS):
 $(LOAD_VCF_PARAMS_TARGETS):
 
-kettle-home/kettle.properties: gen_kettle_properties.php ../../vars
+kettle-home/kettle.properties: gen_kettle_properties.php
 	php -d variables_order=E $< > $@
+
+.PHONY: kettle-home/kettle.properties
 
 ../studies/%:
 	$(MAKE) -C ../studies $*

--- a/solr/Makefile
+++ b/solr/Makefile
@@ -64,7 +64,7 @@ solr/%/conf/schema.xml: solr/% schemas/schema_%.xml
 	test -d solr/$* || $(MAKE) solr/$* #solr/$* is touched on each solr run
 	cp schemas/schema_$*.xml $@
 
-solr/%/conf/data-config.xml: data-config/$(DBSUBDIR)/data-config_%.xml.php ../vars
+solr/%/conf/data-config.xml: data-config/$(DBSUBDIR)/data-config_%.xml.php
 	test -d solr/$* || $(MAKE) solr/$* #solr/$* is touched on each solr run
 	php -d variables_order=E $< > $@
 
@@ -85,4 +85,4 @@ clean:
 clean_cores:
 	find solr -maxdepth 1 -mindepth 1 -type d ! -name bin ! -name collection1 -exec rm -r {} \;
 
-.PHONY: start solr_home clean
+.PHONY: start solr_home clean solr/%/conf/data-config.xml


### PR DESCRIPTION
kettle.properties caches database hostnames and credentials, which is very annoying because that overrides changed vars settings. To prevent
more wasted time, remove them automatically when the vars file is sourced.