### PR TITLE
Fix for microarray upload in postgres

### DIFF
--- a/ddl/postgres/tm_cz/functions/i2b2_process_mrna_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_mrna_data.sql
@@ -1042,7 +1042,8 @@ BEGIN
 			   then case when md.intensity_value > 0 then 1 else 0 end
 			   else 1 end = 1         --	take only >0 for dataType R
 	group by gs.probeset_id
-		  ,sd.assay_id;
+		  ,sd.assay_id
+          ,sd.patient_id;
 	get diagnostics rowCt := ROW_COUNT;
 	exception
 	when others then


### PR DESCRIPTION
This is a fix for the microarray upload procedure, it would not populate patient_id fields in de_subject_microarray_data. Populating these fields at load time eliminates the need to join with subject sample mapping in order to link patient ids to their data.