### PR TITLE
Added libprotoc-dev for ubuntu build

### DIFF
--- a/env/Makefile
+++ b/env/Makefile
@@ -2,7 +2,8 @@ KETTLE_VERSION=4.4.0
 
 UBUNTU_PACKAGES=postgresql make git rsync libcairo-dev php5-cli php5-json curl \
 				tar openjdk-7-jdk gfortran g++ unzip libreadline-dev \
-				libxt-dev libpango1.0-dev texlive-fonts-recommended tex-gyre \
+				libxt-dev libpango1.0-dev libprotoc-dev \
+				texlive-fonts-recommended tex-gyre \
 				fonts-dejavu-core
 
 GROOVY_VERSION=2.1.9


### PR DESCRIPTION
The library libprotoc-dev is required by changes/update to RInterface, see commit https://github.com/tranSMART-Foundation/RInterface/commit/db2f7ce44c04beac7fed218301c3eaab0d043c63 . This addition also documents the requirement for others doing builds.