### PR TITLE
SmartR needs zip on the rserve machine

### DIFF
--- a/env/Makefile
+++ b/env/Makefile
@@ -3,7 +3,7 @@ KETTLE_VERSION=4.4.0
 UBUNTU_PACKAGES=postgresql make git rsync libcairo-dev php5-cli php5-json curl \
 				tar openjdk-7-jdk gfortran g++ unzip libreadline-dev \
 				libxt-dev libpango1.0-dev libprotoc-dev \
-				texlive-fonts-recommended tex-gyre liblz4-tool pv
+				texlive-fonts-recommended tex-gyre liblz4-tool pv zip
 
 GROOVY_VERSION=2.1.9
 


### PR DESCRIPTION
R is directly using the zip executable to create zip files. Such is the
design of the R zip package.