### PR TITLE
/transmart-rest-api-version oauth setting

### DIFF
--- a/config/Config-template.groovy
+++ b/config/Config-template.groovy
@@ -413,6 +413,7 @@ grails { plugin { springsecurity {
                 '/observations/**': securedResourcesFilters,
                 '/patient_sets/**': securedResourcesFilters,
                 '/oauth/inspectToken': securedResourcesFilters,
+                '/transmart-rest-api-version': 'none',
                 '/**': [
                         'JOINED_FILTERS',
                         '-statelessSecurityContextPersistenceFilter',


### PR DESCRIPTION
Add oauth setting for new resource to config template.

the api version may be useful in determining how to authenticate, so it should be available before authentication of a client. It just returns a single number, so there is no private data involved. If more security is necessary a site can always change their local settings.