### PR TITLE
Fixes and upgrades

### DIFF
--- a/ddl/postgres/biomart_user/functions/i2b2_bulk_add_search_term.sql
+++ b/ddl/postgres/biomart_user/functions/i2b2_bulk_add_search_term.sql
@@ -184,7 +184,7 @@ BEGIN
     EXCEPTION
   WHEN OTHERS THEN
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
     cz_end_audit (jobID, 'FAIL');
   

--- a/ddl/postgres/biomart_user/functions/i2b2_metabolomics_zscore_calc.sql
+++ b/ddl/postgres/biomart_user/functions/i2b2_metabolomics_zscore_calc.sql
@@ -394,13 +394,13 @@ BEGIN
 
   WHEN invalid_runType or trial_mismatch or trial_missing then
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
   
     cz_end_audit (jobID, 'FAIL');
   when OTHERS THEN
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 
 
     cz_end_audit (jobID, 'FAIL');

--- a/ddl/postgres/deapp/de_subject_proteomics_data.sql
+++ b/ddl/postgres/deapp/de_subject_proteomics_data.sql
@@ -10,8 +10,8 @@ CREATE TABLE de_subject_proteomics_data (
     gene_id bigint,
     assay_id bigint,
     subject_id character varying(100),
-    intensity bigint,
-    zscore bigint,
+    intensity double precision,
+    zscore double precision,
     partition_id numeric
 );
 

--- a/ddl/postgres/deapp/functions/i2b2_process_rna_seq_data.sql
+++ b/ddl/postgres/deapp/functions/i2b2_process_rna_seq_data.sql
@@ -972,36 +972,36 @@ BEGIN
 	EXCEPTION
 	--when unmapped_patients then
 	--	cz_write_audit(jobId,databasename,procedurename,'No site_id/subject_id mapped to patient_dimension',1,stepCt,'ERROR');
-	--	cz_error_handler(jobid,procedurename);
+	--	cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 	--	cz_end_audit (jobId,'FAIL');
 	when missing_platform then
 		cz_write_audit(jobId,databasename,procedurename,'Platform data missing from one or more subject_sample mapping records',1,stepCt,'ERROR');
-		cz_error_handler(jobid,procedurename);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		PERFORM 161 into rtn_code ;
 	when missing_tissue then
 		cz_write_audit(jobId,databasename,procedurename,'Tissue Type data missing from one or more subject_sample mapping records',1,stepCt,'ERROR');
-		cz_error_handler(jobid,procedurename);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		CZ_END_AUDIT (JOBID,'FAIL');
 		PERFORM 162 into rtn_code ;
 	/*when unmapped_platform then
 		cz_write_audit(jobId,databasename,procedurename,'Platform not found in de_RNA_annotation',1,stepCt,'ERROR');
-		CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		select 163 into rtn_code from dual;*/
 	when multiple_platform then
 		cz_write_audit(jobId,databasename,procedurename,'Multiple platforms for sample_cd in lt_src_RNA_SEQ_subj_samp_map',1,stepCt,'ERROR');
-		CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		PERFORM 164 into rtn_code ;
 	/*when no_probeset_recs then
 		cz_write_audit(jobId,databasename,procedurename,'Unable to match probesets to platform in probeset_deapp',1,stepCt,'ERROR');
-		CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		select 165 into rtn_code from dual;*/
 	WHEN OTHERS THEN
 		--Handle errors.
-		cz_error_handler (jobID, procedureName);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		--End Proc
 		cz_end_audit (jobID, 'FAIL');
 		PERFORM 166 into rtn_code ;

--- a/ddl/postgres/tm_cz/de_subj_protein_data_release.sql
+++ b/ddl/postgres/tm_cz/de_subj_protein_data_release.sql
@@ -4,7 +4,7 @@
 CREATE TABLE de_subj_protein_data_release (
     trial_name character varying(15),
     component character varying(15),
-    intensity bigint,
+    intensity double precision,
     patient_id bigint,
     subject_id character varying(100),
     gene_symbol character varying(100),
@@ -12,10 +12,10 @@ CREATE TABLE de_subj_protein_data_release (
     assay_id bigint,
     timepoint character varying(20),
     n_value bigint,
-    mean_intensity bigint,
-    stddev_intensity bigint,
-    median_intensity bigint,
-    zscore bigint,
+    mean_intensity double precision,
+    stddev_intensity double precision,
+    median_intensity double precision,
+    zscore double precision,
     release_study character varying(15)
 );
 

--- a/ddl/postgres/tm_cz/de_subject_rbm_data_release.sql
+++ b/ddl/postgres/tm_cz/de_subject_rbm_data_release.sql
@@ -14,11 +14,11 @@ CREATE TABLE de_subject_rbm_data_release (
     timepoint character varying(100),
     data_uid character varying(100),
     value bigint,
-    log_intensity bigint,
-    mean_intensity bigint,
-    stddev_intensity bigint,
-    median_intensity bigint,
-    zscore bigint,
+    log_intensity double precision,
+    mean_intensity double precision,
+    stddev_intensity double precision,
+    median_intensity double precision,
+    zscore double precision,
     rbm_panel character varying(50),
     release_study character varying(15)
 );

--- a/ddl/postgres/tm_cz/functions/cz_audit_example.sql
+++ b/ddl/postgres/tm_cz/functions/cz_audit_example.sql
@@ -61,7 +61,7 @@ BEGIN
   EXCEPTION
   WHEN OTHERS THEN
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
     cz_end_audit (jobID, 'FAIL');
 

--- a/ddl/postgres/tm_cz/functions/i2b2_add_snp_biomarker_nodes.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_add_snp_biomarker_nodes.sql
@@ -267,7 +267,7 @@ BEGIN
 
   WHEN OTHERS THEN
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
     cz_end_audit (jobID, 'FAIL'); 
 

--- a/ddl/postgres/tm_cz/functions/i2b2_bulk_add_search_term.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_bulk_add_search_term.sql
@@ -184,7 +184,7 @@ BEGIN
     EXCEPTION
   WHEN OTHERS THEN
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
     cz_end_audit (jobID, 'FAIL');
   

--- a/ddl/postgres/tm_cz/functions/i2b2_load_clinical_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_load_clinical_data.sql
@@ -286,7 +286,7 @@ BEGIN
   
 	update tm_wz.wrk_clinical_data
 	set data_type = 'T'
-	   ,category_path = replace(replace(category_cd,'_',' '),'+','\')
+	   ,category_path = regexp_replace(regexp_replace(replace(category_cd,'_',' '),'([^\\])\+','\1\','g'),'\\\+','+','g')
 	   ,usubjid = REGEXP_REPLACE(TrialID || ':' || coalesce(site_id,'') || ':' || subject_id,
                    '(::){1,}', ':', 'g'); 
 	 get diagnostics rowCt := ROW_COUNT;
@@ -535,7 +535,7 @@ BEGIN
 	
 	begin
 	update tm_wz.wrk_clinical_data
-	set data_label=replace(replace(replace(replace(data_label,'%',' Pct'),'&',' and '),'+',' and '),'_',' ')
+	set data_label=replace(regexp_replace(regexp_replace(replace(replace(data_label,'%',' Pct'),'&',' and '),'([^\\])\+','\1 and ','g'),'\\\+','+','g'),'_',' ')
 	   ,data_value=replace(replace(replace(data_value,'%',' Pct'),'&',' and '),'+',' and ')
 	   ,category_cd=replace(replace(category_cd,'%',' Pct'),'&',' and ')
 	   ,category_path=replace(replace(category_path,'%',' Pct'),'&',' and ');

--- a/ddl/postgres/tm_cz/functions/i2b2_load_sample_categories.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_load_sample_categories.sql
@@ -127,7 +127,7 @@ BEGIN
 	exception
 	when others then
 		--Handle errors.
-		cz_error_handler (jobID, procedureName);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		
 		--End Proc
 		cz_end_audit (jobID, 'FAIL');

--- a/ddl/postgres/tm_cz/functions/i2b2_metabolomics_zscore_calc.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_metabolomics_zscore_calc.sql
@@ -394,13 +394,13 @@ BEGIN
 
   WHEN invalid_runType or trial_mismatch or trial_missing then
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
   
     cz_end_audit (jobID, 'FAIL');
   when OTHERS THEN
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 
 
     cz_end_audit (jobID, 'FAIL');

--- a/ddl/postgres/tm_cz/functions/i2b2_mirna_zscore_calc.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_mirna_zscore_calc.sql
@@ -61,7 +61,7 @@ BEGIN
 		stepCt := stepCt + 1;
 		get diagnostics rowCt := ROW_COUNT;
 		select cz_write_audit(jobId,databaseName,procedureName,'Invalid runType passed - procedure exiting',rowCt,stepCt,'Done') into rtnCd;
-		select cz_error_handler (jobID, procedureName) into rtnCd;  
+		select cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM) into rtnCd;  
 		select cz_end_audit (jobID, 'FAIL') into rtnCd;
 		return 150;
 	end if;
@@ -77,7 +77,7 @@ BEGIN
 			stepCt := stepCt + 1;
 			get diagnostics rowCt := ROW_COUNT;
 			select cz_write_audit(jobId,databaseName,procedureName,'TrialId not the same as trial in WT_SUBJECT_MIRNA_PROBESET - procedure exiting',rowCt,stepCt,'Done') into rtnCd;
-			select cz_error_handler(jobID, procedureName) into rtnCd;
+			select cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM) into rtnCd;
 			select cz_end_audit (jobID, 'FAIL') into rtnCd;
 			return 161;
 		end if;

--- a/ddl/postgres/tm_cz/functions/i2b2_move_node.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_move_node.sql
@@ -109,7 +109,7 @@ BEGIN
 	EXCEPTION
 	WHEN OTHERS THEN
 		--Handle errors.
-		cz_error_handler (jobID, procedureName);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		--End Proc
 		cz_end_audit (jobID, 'FAIL');
 		

--- a/ddl/postgres/tm_cz/functions/i2b2_mrna_index_maint.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_mrna_index_maint.sql
@@ -265,7 +265,7 @@ BEGIN
 	EXCEPTION
 	WHEN OTHERS THEN
 		--Handle errors.
-		cz_error_handler (jobID, procedureName);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		
 		--End Proc
 		cz_end_audit (jobID, 'FAIL');

--- a/ddl/postgres/tm_cz/functions/i2b2_mrna_zscore_calc.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_mrna_zscore_calc.sql
@@ -378,12 +378,12 @@ BEGIN
 
   WHEN invalid_runType or trial_mismatch or trial_missing then
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
     cz_end_audit (jobID, 'FAIL');
   when OTHERS THEN
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
     cz_end_audit (jobID, 'FAIL');
 	

--- a/ddl/postgres/tm_cz/functions/i2b2_process_metabolomic_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_metabolomic_data.sql
@@ -146,7 +146,7 @@ BEGIN
 	
 	if pCount > 0 then
 		perform cz_write_audit(jobId,databasename,procedurename,'Platform data missing from one or more subject_sample mapping records',1,stepCt,'ERROR');
-		perform cz_error_handler(jobid,procedurename);
+		perform cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		select cz_end_audit (jobId,'FAIL') into rtnCd;
 		return 161;
 	end if;
@@ -163,7 +163,7 @@ BEGIN
 	
 	if PCOUNT = 0 then
 		perform cz_write_audit(jobId,databasename,procedurename,'Platform not found in de_qpcr_metabolomics_annotation',1,stepCt,'ERROR');
-		perform CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		perform cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		select cz_end_audit (jobId,'FAIL') into rtnCd;
 		RETURN 163;
 	end if;
@@ -176,7 +176,7 @@ BEGIN
 	
 	if pCount > 0 then
 		perform cz_write_audit(jobId,databasename,procedurename,'Tissue Type data missing from one or more subject_sample mapping records',1,stepCt,'ERROR');
-		perform cz_error_handler(jobid,procedurename);
+		perform cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		select CZ_END_AUDIT (JOBID,'FAIL') into rtnCd;
 		return 162;
 	end if;
@@ -191,7 +191,7 @@ BEGIN
 	
 	if pCount > 0 then
 		perform cz_write_audit(jobId,databasename,procedurename,'Multiple platforms for sample_cd in LT_SRC_METABOLOMIC_MAP',1,stepCt,'ERROR');
-		perform CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		perform cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		select cz_end_audit (jobId,'FAIL') into rtnCd;
 		RETURN 164;
 	end if;

--- a/ddl/postgres/tm_cz/functions/i2b2_process_rna_seq_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_rna_seq_data.sql
@@ -163,7 +163,7 @@ BEGIN
 	
 	if pCount > 0 then
 		select cz_write_audit(jobId,databasename,procedurename,'Multiple platforms for sample_cd in lt_src_RNA_SEQ_subj_samp_map',1,stepCt,'ERROR') into rtnCd;
-		select CZ_ERROR_HANDLER(JOBID,PROCEDURENAME) into rtnCd;
+		select cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM) into rtnCd;
 		select cz_end_audit (jobId,'FAIL') into rtnCd;
 		return 164;
 	end if;

--- a/ddl/postgres/tm_cz/functions/i2b2_proteomics_zscore_calc.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_proteomics_zscore_calc.sql
@@ -61,7 +61,7 @@ BEGIN
 		stepCt := stepCt + 1;
 		get diagnostics rowCt := ROW_COUNT;
 		select cz_write_audit(jobId,databaseName,procedureName,'Invalid runType passed - procedure exiting',rowCt,stepCt,'Done') into rtnCd;
-		select cz_error_handler (jobID, procedureName) into rtnCd;  
+		select cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM) into rtnCd;  
 		select cz_end_audit (jobID, 'FAIL') into rtnCd;
 		return 150;
 	end if;
@@ -77,7 +77,7 @@ BEGIN
 			stepCt := stepCt + 1;
 			get diagnostics rowCt := ROW_COUNT;
 			select cz_write_audit(jobId,databaseName,procedureName,'TrialId not the same as trial in WT_SUBJECT_PROTEOMICS_PROBESET - procedure exiting',rowCt,stepCt,'Done') into rtnCd;
-			select cz_error_handler(jobID, procedureName) into rtnCd;
+			select cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM) into rtnCd;
 			select cz_end_audit (jobID, 'FAIL') into rtnCd;
 			return 161;
 		end if;

--- a/ddl/postgres/tm_cz/functions/i2b2_rbm_zscore_calc_new.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_rbm_zscore_calc_new.sql
@@ -387,13 +387,13 @@ where not exists( select * from deapp.de_rbm_data_annotation_join j where j.data
 
   WHEN invalid_runType or trial_mismatch or trial_missing then
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
     --End Proc
   
     cz_end_audit (jobID, 'FAIL');
   when OTHERS THEN
     --Handle errors.
-    cz_error_handler (jobID, procedureName);
+    cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 
 
     cz_end_audit (jobID, 'FAIL');

--- a/ddl/postgres/tm_cz/functions/i2b2_rna_seq_zscore_calc.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_rna_seq_zscore_calc.sql
@@ -115,7 +115,7 @@ BEGIN
 		stepCt := stepCt + 1;
 		select cz_write_audit(jobId,databaseName,procedureName,'Invalid runType passed - procedure exiting'
 ,0,stepCt,'Done') into rtnCd;
-		select cz_error_handler (jobID, procedureName) into rtnCd;
+		select cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM) into rtnCd;
 		select cz_end_audit (jobID, 'FAIL') into rtnCd;
 		return;
 	end if;

--- a/ddl/postgres/tm_cz/functions/i2b2_secure_study.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_secure_study.sql
@@ -122,7 +122,7 @@ BEGIN
 	EXCEPTION
 	WHEN OTHERS THEN
 		--Handle errors.
-		cz_error_handler (jobID, procedureName);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		
 		--End Proc
 		cz_end_audit (jobID, 'FAIL');

--- a/ddl/postgres/tm_cz/functions/rdc_reload_mrna_data.sql
+++ b/ddl/postgres/tm_cz/functions/rdc_reload_mrna_data.sql
@@ -281,26 +281,26 @@ BEGIN
 	EXCEPTION
 	--when unmapped_patients then
 	--	cz_write_audit(jobId,databasename,procedurename,'No site_id/subject_id mapped to patient_dimension',1,stepCt,'ERROR');
-	--	cz_error_handler(jobid,procedurename);
+	--	cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 	--	cz_end_audit (jobId,'FAIL');
 	when missing_platform then
 		cz_write_audit(jobId,databasename,procedurename,'Platform data missing from one or more subject_sample mapping records',1,stepCt,'ERROR');
-		cz_error_handler(jobid,procedurename);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		--select 16 into rtn_code from dual;
 	when missing_tissue then
 		cz_write_audit(jobId,databasename,procedurename,'Tissue Type data missing from one or more subject_sample mapping records',1,stepCt,'ERROR');
-		cz_error_handler(jobid,procedurename);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		CZ_END_AUDIT (JOBID,'FAIL');
 		--select 16 into rtn_code from dual;
 	when unmapped_platform then
 		cz_write_audit(jobId,databasename,procedurename,'Platform not found in de_mrna_annotation',1,stepCt,'ERROR');
-		CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		--select 16 into rtn_code from dual;
 	WHEN OTHERS THEN
 		--Handle errors.
-		cz_error_handler (jobID, procedureName);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		--End Proc
 		cz_end_audit (jobID, 'FAIL');
 		--select 16 into rtn_code from dual;

--- a/ddl/postgres/tm_cz/functions/upgrade_mrna_data.sql
+++ b/ddl/postgres/tm_cz/functions/upgrade_mrna_data.sql
@@ -161,7 +161,7 @@ BEGIN
 	EXCEPTION
 	WHEN OTHERS THEN
 		--Handle errors.
-		cz_error_handler (jobID, procedureName);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		--End Proc
 		cz_end_audit (jobID, 'FAIL');
 	

--- a/ddl/postgres/tm_lz/functions/i2b2_process_qpcr_mirna_data.sql
+++ b/ddl/postgres/tm_lz/functions/i2b2_process_qpcr_mirna_data.sql
@@ -979,36 +979,36 @@ BEGIN
 	EXCEPTION
 	--when unmapped_patients then
 	--	cz_write_audit(jobId,databasename,procedurename,'No site_id/subject_id mapped to patient_dimension',1,stepCt,'ERROR');
-	--	cz_error_handler(jobid,procedurename);
+	--	cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 	--	cz_end_audit (jobId,'FAIL');
 	when missing_platform then
 		cz_write_audit(jobId,databasename,procedurename,'Platform data missing from one or more subject_sample mapping records',1,stepCt,'ERROR');
-		cz_error_handler(jobid,procedurename);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		PERFORM 161 into rtn_code ;
 	when missing_tissue then
 		cz_write_audit(jobId,databasename,procedurename,'Tissue Type data missing from one or more subject_sample mapping records',1,stepCt,'ERROR');
-		cz_error_handler(jobid,procedurename);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		CZ_END_AUDIT (JOBID,'FAIL');
 		PERFORM 162 into rtn_code ;
 	when unmapped_platform then
 		cz_write_audit(jobId,databasename,procedurename,'Platform not found in de_qpcr_mirna_annotation',1,stepCt,'ERROR');
-		CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		PERFORM 163 into rtn_code ;--mod
 	when multiple_platform then
 		cz_write_audit(jobId,databasename,procedurename,'Multiple platforms for sample_cd in LT_SRC_MIRNA_SUBJ_SAMP_MAP',1,stepCt,'ERROR');
-		CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		PERFORM 164 into rtn_code ;
 	when no_probeset_recs then
 		cz_write_audit(jobId,databasename,procedurename,'Unable to match probesets to platform in probeset_deapp',1,stepCt,'ERROR');
-		CZ_ERROR_HANDLER(JOBID,PROCEDURENAME);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		cz_end_audit (jobId,'FAIL');
 		PERFORM 165 into rtn_code ;
 	WHEN OTHERS THEN
 		--Handle errors.
-		cz_error_handler (jobID, procedureName);
+		cz_error_handler(jobId, procedureName, SQLSTATE, SQLERRM);
 		--End Proc
 		cz_end_audit (jobID, 'FAIL');
 		PERFORM 16  into rtn_code ;

--- a/ddl/postgres/tm_wz/wt_subject_metabolomics_med.sql
+++ b/ddl/postgres/tm_wz/wt_subject_metabolomics_med.sql
@@ -3,8 +3,8 @@
 --
 CREATE TABLE wt_subject_metabolomics_med (
     probeset character varying(500),
-    intensity_value bigint,
-    log_intensity bigint,
+    intensity_value double precision,
+    log_intensity double precision,
     assay_id bigint,
     patient_id bigint,
     sample_id bigint,
@@ -13,9 +13,9 @@ CREATE TABLE wt_subject_metabolomics_med (
     timepoint character varying(100),
     pvalue double precision,
     num_calls bigint,
-    mean_intensity bigint,
-    stddev_intensity bigint,
-    median_intensity bigint,
-    zscore bigint
+    mean_intensity double precision,
+    stddev_intensity double precision,
+    median_intensity double precision,
+    zscore double precision
 );
 

--- a/ddl/postgres/tm_wz/wt_subject_rbm_calcs.sql
+++ b/ddl/postgres/tm_wz/wt_subject_rbm_calcs.sql
@@ -4,9 +4,9 @@
 CREATE TABLE wt_subject_rbm_calcs (
     trial_name character varying(50),
     probeset_id character varying(1000),
-    mean_intensity bigint,
-    median_intensity bigint,
-    stddev_intensity bigint
+    mean_intensity double precision,
+    median_intensity double precision,
+    stddev_intensity double precision
 );
 
 --

--- a/ddl/postgres/tm_wz/wt_subject_rbm_logs.sql
+++ b/ddl/postgres/tm_wz/wt_subject_rbm_logs.sql
@@ -12,7 +12,7 @@ CREATE TABLE wt_subject_rbm_logs (
     subject_id character varying(100),
     trial_name character varying(50),
     timepoint character varying(100),
-    log_intensity bigint
+    log_intensity double precision
 );
 
 --

--- a/ddl/postgres/tm_wz/wt_subject_rbm_med.sql
+++ b/ddl/postgres/tm_wz/wt_subject_rbm_med.sql
@@ -3,8 +3,8 @@
 --
 CREATE TABLE wt_subject_rbm_med (
     probeset_id character varying(1000),
-    intensity_value bigint,
-    log_intensity bigint,
+    intensity_value double precision,
+    log_intensity double precision,
     assay_id bigint,
     patient_id bigint,
     sample_id bigint,
@@ -13,9 +13,9 @@ CREATE TABLE wt_subject_rbm_med (
     timepoint character varying(100),
     pvalue double precision,
     num_calls bigint,
-    mean_intensity bigint,
-    stddev_intensity bigint,
-    median_intensity bigint,
-    zscore bigint
+    mean_intensity double precision,
+    stddev_intensity double precision,
+    median_intensity double precision,
+    zscore double precision
 );
 

--- a/ddl/postgres/tm_wz/wt_subject_rna_calcs.sql
+++ b/ddl/postgres/tm_wz/wt_subject_rna_calcs.sql
@@ -4,9 +4,9 @@
 CREATE TABLE wt_subject_rna_calcs (
     trial_name character varying(50),
     probeset_id character varying(200),
-    mean_intensity bigint,
-    median_intensity bigint,
-    stddev_intensity bigint
+    mean_intensity double precision,
+    median_intensity double precision,
+    stddev_intensity double precision
 );
 
 --

--- a/ddl/postgres/tm_wz/wt_subject_rna_logs.sql
+++ b/ddl/postgres/tm_wz/wt_subject_rna_logs.sql
@@ -3,7 +3,7 @@
 --
 CREATE TABLE wt_subject_rna_logs (
     probeset_id character varying(200),
-    intensity_value bigint,
+    intensity_value double precision,
     pvalue double precision,
     num_calls bigint,
     assay_id bigint,
@@ -12,7 +12,7 @@ CREATE TABLE wt_subject_rna_logs (
     subject_id character varying(100),
     trial_name character varying(50),
     timepoint character varying(100),
-    log_intensity bigint
+    log_intensity double precision
 );
 
 --

--- a/ddl/postgres/tm_wz/wt_subject_rna_med.sql
+++ b/ddl/postgres/tm_wz/wt_subject_rna_med.sql
@@ -3,8 +3,8 @@
 --
 CREATE TABLE wt_subject_rna_med (
     probeset_id character varying(200),
-    intensity_value bigint,
-    log_intensity bigint,
+    intensity_value double precision,
+    log_intensity double precision,
     assay_id bigint,
     patient_id bigint,
     sample_id bigint,
@@ -13,9 +13,9 @@ CREATE TABLE wt_subject_rna_med (
     timepoint character varying(100),
     pvalue double precision,
     num_calls bigint,
-    mean_intensity bigint,
-    stddev_intensity bigint,
-    median_intensity bigint,
-    zscore bigint
+    mean_intensity double precision,
+    stddev_intensity double precision,
+    median_intensity double precision,
+    zscore double precision
 );
 


### PR DESCRIPTION
- Fixed a number of column data types that should be double precision instead of integer,
- Fixed references to a cz_error_handler with 2 arguments,
- Added code to allow escape of + character in clinical data variable names with a backslash

All changes are for postgres only
