### PR TITLE
Metabolomics pipeline fixes

### DIFF
--- a/ddl/postgres/deapp/de_variant_subject_summary.sql
+++ b/ddl/postgres/deapp/de_variant_subject_summary.sql
@@ -16,7 +16,7 @@ CREATE TABLE de_variant_subject_summary (
     chr character varying(50),
     pos bigint,
     dataset_id character varying(50) NOT NULL,
-    subject_id character varying(50) NOT NULL,
+    subject_id character varying(100) NOT NULL,
     rs_id character varying(500),
     variant character varying(1000),
     variant_format character varying(100),

--- a/ddl/postgres/i2b2demodata/patient_dimension.sql
+++ b/ddl/postgres/i2b2demodata/patient_dimension.sql
@@ -9,7 +9,7 @@ CREATE TABLE patient_dimension (
     sex_cd character varying(50),
     age_in_years_num numeric(38,0),
     language_cd character varying(50),
-    race_cd character varying(50),
+    race_cd character varying(100),
     marital_status_cd character varying(50),
     religion_cd character varying(50),
     zip_cd character varying(50),

--- a/ddl/postgres/tm_cz/functions/i2b2_load_rbm_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_load_rbm_data.sql
@@ -37,7 +37,6 @@ DECLARE
   gplTitle		varchar(1000);
   pExists		bigint;
   partTbl   	bigint;
-  partExists 	bigint;
   sampleCt		bigint;
   idxExists 	bigint;
   logBase		bigint;
@@ -324,22 +323,7 @@ BEGIN
 	stepCt := stepCt + 1;
 	select tm_cz.cz_write_audit(jobId,databaseName,procedureName,'Delete data from observation_fact',rowCt,stepCt,'Done') into rtnCd;
 	
-	select count(*) into partExists
-	from deapp.de_subject_sample_mapping sm
-	where sm.trial_name = TrialId
-	and coalesce(sm.source_cd,'STD') = sourceCd
-	and sm.platform = 'RBM'
-	and sm.partition_id is not null;
-	
-	if partExists = 0 then
-		select nextval('deapp.seq_rbm_partition_id') into partitionId;
-	else
-		select distinct partition_id into partitionId
-		from deapp.de_subject_sample_mapping sm
-		where sm.trial_name = TrialId
-		and coalesce(sm.source_cd,'STD') = sourceCd
-		and sm.platform = 'RBM';
-	end if;
+	select nextval('deapp.seq_rbm_partition_id') into partitionId;
 
 	partitionName := 'deapp.de_subject_rbm_data_' || partitionId::text;
 	partitionIndx := 'de_subject_rbm_data_' || partitionId::text;

--- a/ddl/postgres/tm_cz/functions/i2b2_metabolomics_zscore_calc.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_metabolomics_zscore_calc.sql
@@ -546,7 +546,7 @@ select tm_cz.cz_error_handler (jobID, procedureName, errorNumber, errorMessage) 
 			,subject_id
 			)
 			select probeset
-				  ,intensity_value  
+				  ,log_base ^ intensity_value  
 				  ,assay_id 
 				  ,intensity_value
 				  ,patient_id
@@ -565,7 +565,7 @@ select tm_cz.cz_error_handler (jobID, procedureName, errorNumber, errorMessage) 
 			select probeset
 				  ,intensity_value 
 				  ,assay_id 
-				  ,log(2.0,cast(intensity_value as numeric))   -- wt_subject_mbolomics_probeset should only contain strictly positive intensities, otherwise throwing an error here is correct thing to do
+				  ,log(log_base,cast(intensity_value as numeric))   -- wt_subject_mbolomics_probeset should only contain strictly positive intensities, otherwise throwing an error here is correct thing to do
 				  ,patient_id
 				  ,subject_id
 			from WT_SUBJECT_MBOLOMICS_PROBESET

--- a/ddl/postgres/tm_cz/functions/i2b2_metabolomics_zscore_calc.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_metabolomics_zscore_calc.sql
@@ -171,7 +171,7 @@ BEGIN
 			,subject_id
 			)
 			PERFORM probeset
-				  ,intensity_value  
+				  ,log_base ^ intensity_value  
 				  ,assay_id 
 				  ,intensity_value
 				  ,patient_id
@@ -195,7 +195,7 @@ BEGIN
 			PERFORM probeset
 				  ,intensity_value 
 				  ,assay_id 
-				  ,log(2.0,intensity_value)
+				  ,log(log_base,intensity_value)
 				  ,patient_id
 		--		  ,sample_cd
 				  ,subject_id

--- a/ddl/postgres/tm_cz/functions/i2b2_process_acgh_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_acgh_data.sql
@@ -356,16 +356,8 @@ BEGIN
 	  and sm.platform = 'ACGH'
 	  and sm.partition_id is not null;
 
-	if partExists = 0 then
-		select nextval('deapp.seq_mrna_partition_id') into partitionId;
-	else
-		select distinct partition_id into partitionId
-		from deapp.de_subject_sample_mapping sm
-		where sm.trial_name = TrialId
-		  and coalesce(sm.source_cd,'STD') = sourceCd
-		--  and sm.platform = 'MRNA_AFFYMETRIX';
-		  and sm.platform = 'ACGH';
-	end if;
+	-- take new partition regardless of partExists, but we need the partExists value later
+	select nextval('deapp.seq_mrna_partition_id') into partitionId;
 
 	partitionName := 'deapp.de_subject_acgh_data_' || partitionId::text;
 	partitionIndx := 'de_subject_acgh_data_' || partitionId::text;

--- a/ddl/postgres/tm_cz/functions/i2b2_process_metabolomic_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_metabolomic_data.sql
@@ -41,7 +41,6 @@ Declare
   gplTitle		varchar(1000);
   pExists		bigint;
   partTbl   	bigint;
-  partExists 	bigint;
   sampleCt		bigint;
   idxExists 	bigint;
   logBase		bigint;
@@ -321,23 +320,8 @@ BEGIN
 	stepCt := stepCt + 1;
 	perform cz_write_audit(jobId,databaseName,procedureName,'Delete data from observation_fact',rowCt,stepCt,'Done');
 
-	select count(*) into partExists
-	from deapp.de_subject_sample_mapping sm
-	where sm.trial_name = TrialId
-	and coalesce(sm.source_cd,'STD') = sourceCd
-	and sm.platform = 'METABOLOMICS'
-	and sm.partition_id is not null;
+	select nextval('deapp.seq_metabolomics_partition_id') into partitionId;
 	
-	if partExists = 0 then
-		select nextval('deapp.seq_metabolomics_partition_id') into partitionId;
-	else
-		select distinct partition_id into partitionId
-		from deapp.de_subject_sample_mapping sm
-		where sm.trial_name = TrialId
-		and coalesce(sm.source_cd,'STD') = sourceCd
-		and sm.platform = 'METABOLOMICS';
-	end if;
-
 	partitionName := 'deapp.de_subject_metabolomics_data_' || partitionId::text;
 	partitionIndx := 'de_subject_metabolomics_data_' || partitionId::text;
 

--- a/ddl/postgres/tm_cz/functions/i2b2_process_metabolomic_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_metabolomic_data.sql
@@ -341,27 +341,6 @@ BEGIN
 	partitionName := 'deapp.de_subject_metabolomics_data_' || partitionId::text;
 	partitionIndx := 'de_subject_metabolomics_data_' || partitionId::text;
 
-	--	Cleanup any existing data in de_subject_sample_mapping.  
-	begin
-	delete from DE_SUBJECT_SAMPLE_MAPPING 
-	where trial_name = TrialID 
-	  and coalesce(source_cd,'STD') = sourceCd
-	  and platform = 'METABOLOMICS'; --Making sure only metabolomic data is deleted
-	  get diagnostics rowCt := ROW_COUNT;
-	  exception
-	when others then
-		errorNumber := SQLSTATE;
-		errorMessage := SQLERRM;
-		--Handle errors.
-		select tm_cz.cz_error_handler (jobID, procedureName, errorNumber, errorMessage) into rtnCd;
-		--End Proc
-		select tm_cz.cz_end_audit (jobID, 'FAIL') into rtnCd;
-		return -16;
-	end;
-		  
-	stepCt := stepCt + 1;
-	perform cz_write_audit(jobId,databaseName,procedureName,'Delete trial from DEAPP de_subject_sample_mapping',rowCt,stepCt,'Done');
-
 --	truncate tmp node table
 
 	EXECUTE('truncate table tm_wz.WT_METABOLOMIC_NODES');

--- a/ddl/postgres/tm_cz/functions/i2b2_process_mrna_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_mrna_data.sql
@@ -49,7 +49,6 @@ Declare
 	gplTitle		varchar(1000);
 	pExists			numeric;
 	partTbl   		numeric;
-	partExists 		numeric;
 	sampleCt		numeric;
 	idxExists 		numeric;
 	logBase			numeric;
@@ -357,25 +356,9 @@ BEGIN
 	stepCt := stepCt + 1;
 	select tm_cz.cz_write_audit(jobId,databaseName,procedureName,'Delete data from observation_fact',rowCt,stepCt,'Done') into rtnCd;
 
-	--	check if trial/source_cd already loaded, if yes, get existing partition_id else get new one
-
-	select count(*) into partExists
-	from deapp.de_subject_sample_mapping sm
-	where sm.trial_name = TrialId
-	  and coalesce(sm.source_cd,'STD') = sourceCd
-	  and sm.platform = 'MRNA_AFFYMETRIX'
-	  and sm.partition_id is not null;
-
-	if partExists = 0 then
-		select nextval('deapp.seq_mrna_partition_id') into partitionId;
-	else
-		select distinct partition_id into partitionId
-		from deapp.de_subject_sample_mapping sm
-		where sm.trial_name = TrialId
-		  and coalesce(sm.source_cd,'STD') = sourceCd
-		  and sm.platform = 'MRNA_AFFYMETRIX';
-	end if;
-
+	--	get next partitionId
+    select nextval('deapp.seq_mrna_partition_id') into partitionId;
+	
 	partitionName := 'deapp.de_subject_microarray_data_' || partitionId::text; -- revert to using partitions
 	partitionIndx := 'de_subject_microarray_data_' || partitionId::text; -- revert to using partitions
 	-- partitionName := 'deapp.de_subject_microarray_data';

--- a/ddl/postgres/tm_cz/functions/i2b2_process_proteomics_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_proteomics_data.sql
@@ -35,7 +35,6 @@ Declare
   gplTitle		character varying(1000);
   pExists		numeric;
   partTbl   	numeric;
-  partExists 	numeric;
   sampleCt		numeric;
   idxExists 	numeric;
   logBase		numeric;

--- a/ddl/postgres/tm_cz/functions/i2b2_process_proteomics_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_proteomics_data.sql
@@ -306,38 +306,6 @@ BEGIN
 	select cz_write_audit(jobId,databaseName,procedureName,'Delete data from observation_fact',rowCt,stepCt,'Done') into rtnCd;
 
 	begin
-	delete from DE_SUBJECT_PROTEIN_DATA
-	where trial_name = TrialId ;
-	exception
-	when others then
-		perform tm_cz.cz_error_handler (jobID, procedureName, SQLSTATE, SQLERRM);
-		perform tm_cz.cz_end_audit (jobID, 'FAIL');
-		return -16;
-	end;
-	
-	stepCt := stepCt + 1;
-	get diagnostics rowCt := ROW_COUNT;
-	select cz_write_audit(jobId,databaseName,procedureName,'Delete data from DE_SUBJECT_PROTEIN_DATA',rowCt,stepCt,'Done') into rtnCd;
-		
-	--	Cleanup any existing data in de_subject_sample_mapping.  
-
-	begin
-	delete from DE_SUBJECT_SAMPLE_MAPPING ssm
-	where trial_name = TrialID 
-	  and coalesce(ssm.source_cd,'STD') = sourceCd
-	  and platform = 'PROTEIN'
-	; --Making sure only proteomics data is deleted
-	exception
-	when others then
-		perform tm_cz.cz_error_handler (jobID, procedureName, SQLSTATE, SQLERRM);
-		perform tm_cz.cz_end_audit (jobID, 'FAIL');
-		return -16;
-	end;
-		  
-	stepCt := stepCt + 1;
-	get diagnostics rowCt := ROW_COUNT;
-	select cz_write_audit(jobId,databaseName,procedureName,'Delete trial from DEAPP de_subject_sample_mapping',rowCt,stepCt,'Done') into rtnCd;
-	begin
 	execute('truncate table tm_wz.WT_PROTEOMICS_NODES');
 	execute('truncate table tm_wz.WT_PROTEOMICS_NODE_VALUES');
 	exception

--- a/ddl/postgres/tm_cz/functions/i2b2_process_qpcr_mirna_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_qpcr_mirna_data.sql
@@ -315,37 +315,6 @@ BEGIN
 	stepCt := stepCt + 1; get diagnostics rowCt := ROW_COUNT;
 	perform cz_write_audit(jobId,databaseName,procedureName,'Delete data from observation_fact',rowCt,stepCt,'Done');
 	
-        begin
-	delete from de_subject_mirna_data
-	where trial_source = TrialId || ':' || sourceCd;
-	stepCt := stepCt + 1; get diagnostics rowCt := ROW_COUNT;
-	perform cz_write_audit(jobId,databaseName,procedureName,'Delete data from de_subject_mirna_data',rowCt,stepCt,'Done');
-	exception
-	when others then
-		errorNumber := SQLSTATE;
-		errorMessage := SQLERRM;
-		perform tm_cz.cz_error_handler (jobID, procedureName, errorNumber, errorMessage);	
-		perform tm_cz.cz_end_audit (jobID, 'FAIL');
-		return -16;
-	end;
-
-	begin
-	delete from deapp.DE_SUBJECT_SAMPLE_MAPPING d 
-	where trial_name = TrialID 
-	  and coalesce(d.source_cd,'STD') = sourceCd
-	  and platform = mirna_type;
-	exception
-	when others then
-		errorNumber := SQLSTATE;
-		errorMessage := SQLERRM;
-		perform tm_cz.cz_error_handler (jobID, procedureName, errorNumber, errorMessage);	
-		perform tm_cz.cz_end_audit (jobID, 'FAIL');
-		return -16;
-	end;
-	  
-	stepCt := stepCt + 1; get diagnostics rowCt := ROW_COUNT;
-	perform cz_write_audit(jobId,databaseName,procedureName,'Delete trial from DEAPP de_subject_sample_mapping',rowCt,stepCt,'Done');
-
 	begin
 		execute('truncate table tm_wz.WT_QPCR_MIRNA_NODES');
 	exception

--- a/ddl/postgres/tm_cz/functions/i2b2_process_qpcr_mirna_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_qpcr_mirna_data.sql
@@ -36,7 +36,6 @@ Declare
   gplTitle		varchar(1000);
   pExists		numeric;
   partTbl   	numeric;
-  partExists 	numeric;
   sampleCt		numeric;
   idxExists 	numeric;
   logBase		numeric;

--- a/ddl/postgres/tm_cz/functions/i2b2_process_rna_seq_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_rna_seq_data.sql
@@ -34,7 +34,6 @@ DECLARE
   gplTitle		varchar(1000);
   pExists		bigint;
   partTbl   	bigint;
-  partExists 	bigint;
   sampleCt		bigint;
   idxExists 	bigint;
   logBase		bigint;
@@ -213,23 +212,8 @@ BEGIN
 		return -16;
 	end;
 
-	select count(*) into partExists
-	from deapp.de_subject_sample_mapping sm
-	where sm.trial_name = TrialId
-	and coalesce(sm.source_cd,'STD') = sourceCd
-	and sm.platform = 'RNA_AFFYMETRIX'
-	and sm.partition_id is not null;
+	select nextval('deapp.seq_rna_partition_id') into partitionId;
 	
-	if partExists = 0 then
-		select nextval('deapp.seq_rna_partition_id') into partitionId;
-	else
-		select distinct partition_id into partitionId
-		from deapp.de_subject_sample_mapping sm
-		where sm.trial_name = TrialId
-		and coalesce(sm.source_cd,'STD') = sourceCd
-		and sm.platform = 'RNA_AFFYMETRIX';
-	end if;
-
 	partitionName := 'deapp.de_subject_rna_data_' || partitionId::text;
 	partitionIndx := 'de_subject_rna_data_' || partitionId::text;	
 	stepCt := stepCt + 1;

--- a/ddl/postgres/tm_cz/functions/i2b2_process_rna_seq_data.sql
+++ b/ddl/postgres/tm_cz/functions/i2b2_process_rna_seq_data.sql
@@ -310,28 +310,6 @@ BEGIN
 	
 	stepCt := stepCt + 1;
 	select cz_write_audit(jobId,databaseName,procedureName,'Delete data from observation_fact',rowCt,stepCt,'Done') into rtnCd;
-		
-	--	Cleanup any existing data in de_subject_sample_mapping.  
-
-	begin
-	delete from deapp.DE_SUBJECT_SAMPLE_MAPPING 
-	where trial_name = TrialID 
-	  and coalesce(source_cd,'STD') = sourceCd
-	  and platform = 'RNA_AFFYMETRIX'; --Making sure only RNA_sequencing data is deleted
-	get diagnostics rowCt := ROW_COUNT;
-	exception
-	when others then
-		errorNumber := SQLSTATE;
-		errorMessage := SQLERRM;
-		--Handle errors.
-		select tm_cz.cz_error_handler (jobID, procedureName, errorNumber, errorMessage) into rtnCd;
-		--End Proc
-		select tm_cz.cz_end_audit (jobID, 'FAIL') into rtnCd;
-		return -16;
-	end;
-	
-	stepCt := stepCt + 1;
-	select cz_write_audit(jobId,databaseName,procedureName,'Delete trial from DEAPP de_subject_sample_mapping',rowCt,stepCt,'Done') into rtnCd;
 
 --	truncate tmp node table
 

--- a/ddl/postgres/tm_cz/patient_dimension_release.sql
+++ b/ddl/postgres/tm_cz/patient_dimension_release.sql
@@ -9,7 +9,7 @@ CREATE TABLE patient_dimension_release (
     sex_cd character varying(50),
     age_in_years_num bigint,
     language_cd character varying(50),
-    race_cd character varying(50),
+    race_cd character varying(100),
     marital_status_cd character varying(50),
     religion_cd character varying(50),
     zip_cd character varying(50),

--- a/ddl/postgres/tm_cz/tmp_subject_info.sql
+++ b/ddl/postgres/tm_cz/tmp_subject_info.sql
@@ -5,6 +5,6 @@ CREATE TABLE tmp_subject_info (
     usubjid character varying(100),
     age_in_years_num smallint,
     sex_cd character varying(50),
-    race_cd character varying(50)
+    race_cd character varying(100)
 );
 

--- a/ddl/postgres/tm_lz/lt_src_subj_enroll_date.sql
+++ b/ddl/postgres/tm_lz/lt_src_subj_enroll_date.sql
@@ -4,6 +4,6 @@
 CREATE TABLE lt_src_subj_enroll_date (
     study_id character varying(25),
     site_id character varying(50),
-    subject_id character varying(20),
+    subject_id character varying(100),
     enroll_date character varying(25)
 );

--- a/ddl/postgres/tm_lz/lz_src_subj_enroll_date.sql
+++ b/ddl/postgres/tm_lz/lz_src_subj_enroll_date.sql
@@ -4,7 +4,7 @@
 CREATE TABLE lz_src_subj_enroll_date (
     study_id character varying(25),
     site_id character varying(50),
-    subject_id character varying(20),
+    subject_id character varying(100),
     enroll_date character varying(25)
 );
 

--- a/ddl/postgres/tm_wz/wt_clinical_data_dups.sql
+++ b/ddl/postgres/tm_wz/wt_clinical_data_dups.sql
@@ -3,7 +3,7 @@
 --
 CREATE TABLE wt_clinical_data_dups (
     site_id     character varying(50),
-    subject_id  character varying(30),
+    subject_id  character varying(100),
     visit_name  character varying(100),
     data_label  character varying(500),
     category_cd character varying(250),

--- a/ddl/postgres/tm_wz/wt_subject_info.sql
+++ b/ddl/postgres/tm_wz/wt_subject_info.sql
@@ -5,6 +5,6 @@ CREATE TABLE wt_subject_info (
     usubjid character varying(107),
     age_in_years_num smallint,
     sex_cd character varying(50),
-    race_cd character varying(50)
+    race_cd character varying(100)
 );
 


### PR DESCRIPTION
 - Fixes to metabolomics pipeline: 
  - When loading logged data (`datatype=='L'`), it was just copied to raw intensity, now calculates correct value
  - A hard coded value of 2.0 was used for log calculation, now uses provided log_base parameter
  - All previous metabolomics data for the study was being deleted before loading, preventing upload of multiple metabolomics data sets. This block of code was removed. It was also removed for other loading pipelines where it occurred.
 - Various fixes:
  - Increased length of some subject_id fields to 100, in line with other columns
  - Increased length of race_cd fields to 100, there exist quite elaborate descriptions of subject ethnicity
 - Partitioning: changed strategy so that a new partition is created for each loaded high dimensional data set (previously a new partition was created only for a new study). This should improve performance in studies with a large number of high dimensional data sets.