### PR TITLE
change version of php

### DIFF
--- a/env/Makefile
+++ b/env/Makefile
@@ -1,7 +1,7 @@
 KETTLE_VERSION=4.4.0
 TRANSMART_RELEASE_BRANCH=release-16.1
 
-UBUNTU_PACKAGES=postgresql make git rsync libcairo-dev php5-cli php5-json curl \
+UBUNTU_PACKAGES=postgresql make git rsync libcairo-dev php7.0-cli php7.0-json curl \
 				tar openjdk-7-jdk gfortran g++ unzip libreadline-dev \
 				libxt-dev libpango1.0-dev libprotoc-dev \
 				texlive-fonts-recommended tex-gyre liblz4-tool pv zip


### PR DESCRIPTION
Ubuntu 16.04 LTS has switched to PHP 7.0 with a new infrastructure for PHP package. 
So, we can't install php5 on Ubuntu 16.04, but can install PHP 7.0. Under task of create clear database for transmart we should change this names of packages from env/Makefile:

php5-cli php5-json 
to 
php7.0-cli php7.0-json.

See http://askubuntu.com/questions/756879/cant-install-php5-on-ubuntu-16-04 for more informations