### PR TITLE
Fixed ddl file so 'make postgres' doesn't crash

### DIFF
--- a/ddl/postgres/gwas_plink/_misc.sql
+++ b/ddl/postgres/gwas_plink/_misc.sql
@@ -1,7 +1,7 @@
 --
 -- Name: plink_data_plink_data_id.seq; Type: SEQUENCE; Schema: gwas_plink; Owner: -
 --
-CREATE SEQUENCE plink_data_plink_data_id.seq
+CREATE SEQUENCE plink_data_plink_data_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE


### PR DESCRIPTION
Changed the dot to an underscore
The dot caused the first part to be interpreted as a schema