### PR TITLE
Use relative pathing

### DIFF
--- a/config/Config-template.groovy
+++ b/config/Config-template.groovy
@@ -155,7 +155,11 @@ com.recomdata.appTitle = "tranSMART v" + org.transmart.originalConfigBinding.app
 // Location of the help pages. Should be an absolute URL.
 // Currently, these are distribution with transmart,
 // so it can also point to that location copy.
-com.recomdata.adminHelpURL = "$transmartURL/help/adminHelp/default.htm"
+if (transmartURL.startsWith('http://localhost:')) {
+	com.recomdata.adminHelpURL = "/transmart/help/adminHelp/default.htm"
+} else {
+	com.recomdata.adminHelpURL = "$transmartURL/help/adminHelp/default.htm"
+}
 
 environments { development {
     com.recomdata.bugreportURL = 'https://jira.transmartfoundation.org'


### PR DESCRIPTION
If the app is configured to use localhost for transmartURL, the link for help does not work when it is deployed.  Check to see if we are using localhost, and if so, use a relative path, otherwise use the path specified in transmartURL (in case it is configured to point elsewhere).